### PR TITLE
Remove `triggerImmediately`

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -93,16 +93,6 @@ export function trigger(eventId, ...args) {
 }
 
 /**
- * Triggers an event immediately without queueing.
- *
- * @param {string} eventId The event identifier.
- * @param  {...any} args Additional arguments describing the event.
- */
-export function triggerImmediately(eventId, ...args) {
-  handle(eventId, ...args);
-}
-
-/**
  * Clears all registered handlers.
  */
 export function clearHandlers() {

--- a/src/event.test.js
+++ b/src/event.test.js
@@ -2,7 +2,6 @@ import {
   clearHandlers,
   eventQueue,
   trigger,
-  triggerImmediately,
   handler,
   rawHandler,
   injectCause,
@@ -125,22 +124,6 @@ describe("trigger", () => {
   it("logs a warning for unknown events", () => {
     trigger("bar");
     ticker.advance();
-    expect(global.console.warn).toHaveBeenCalledWith(
-      "no handler registered for:",
-      "bar",
-    );
-  });
-});
-
-describe("triggerImmediately", () => {
-  it("calls the registered handler", () => {
-    let handled = 0;
-    handler("foo", () => handled++);
-    triggerImmediately("foo");
-    expect(handled).toBe(1);
-  });
-  it("logs a warning for unknown events", () => {
-    triggerImmediately("bar");
     expect(global.console.warn).toHaveBeenCalledWith(
       "no handler registered for:",
       "bar",

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,6 @@ export {
   handler,
   rawHandler,
   trigger,
-  triggerImmediately,
   injectCause,
   effectsInterceptor,
 } from "./event";


### PR DESCRIPTION
* Maybe just remove it, maybe we can do without it, maybe it does
  not have to be used?