### PR TITLE
Add `tap` maybe

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -154,10 +154,9 @@ export function rawConnector(connectorId, connectorFn) {
  *
  *  s.update("bar"); // => "Got bar, was foo"
  *  s.update("baz"); // => "Got baz, was bar"
- *
  */
-function tap(connectorId, tapFn) {
-  // TODO:!!
+export function tap(connectorId, tapFn) {
+  return connect(connectorId).connect((_, prev, next) => tapFn(next, prev));
 }
 
 /**

--- a/src/connector.js
+++ b/src/connector.js
@@ -135,6 +135,32 @@ export function rawConnector(connectorId, connectorFn) {
 }
 
 /**
+ * Connects the `tapFn` to the connector identified by `connectorId` and starts
+ * applying the stream, from the connected signal, as pairs of current/previous
+ * values.
+ *
+ * @param {string} connectorId The connector identifier.
+ * @param {function} tapFn A function that is mapped over the stream of `curr`
+ *   and `prev` values from the connected signal.
+ *
+ * @example
+ *
+ *  let s = signal("foo");
+ *  rawConnector("myConnector", () => s)
+ *
+ *  tap("myConnector", (curr, prev) => {
+ *    console.log(`Got $curr, was $prev`);
+ *  });
+ *
+ *  s.update("bar"); // => "Got bar, was foo"
+ *  s.update("baz"); // => "Got baz, was bar"
+ *
+ */
+function tap(connectorId, tapFn) {
+  // TODO:!!
+}
+
+/**
  * Clears all registered connectors.
  */
 export function clearConnectors() {

--- a/src/connector.test.js
+++ b/src/connector.test.js
@@ -7,7 +7,6 @@ import {
   tap,
 } from "./connector";
 import { signal, signalFn } from "./signal";
-import { createSecureContext } from "tls";
 
 /* global global */
 

--- a/src/connector.test.js
+++ b/src/connector.test.js
@@ -4,8 +4,10 @@ import {
   connector,
   rawConnector,
   withInputSignals,
+  tap,
 } from "./connector";
 import { signal, signalFn } from "./signal";
+import { createSecureContext } from "tls";
 
 /* global global */
 
@@ -113,5 +115,23 @@ describe("clearConnectors", () => {
     expect(s1).not.toBe(s2);
     expect(s1).toBeTruthy();
     expect(s2).toBeFalsy();
+  });
+});
+
+describe("tap", () => {
+  it("applies tapFn with curr, prev from the tapped signal", () => {
+    let s = signal("foo");
+    connector("conn", () => s.value());
+    let pairs = [];
+    tap("conn", (curr, prev) => {
+      pairs.push(`${curr}-${prev}`);
+    });
+    s.reset("bar");
+    s.reset("baz");
+    s.reset("goo");
+    expect(pairs.length).toBe(3);
+    expect(pairs[0]).toBe("bar-foo");
+    expect(pairs[1]).toBe("baz-bar");
+    expect(pairs[2]).toBe("goo-baz");
   });
 });


### PR DESCRIPTION
So I've just put in the most simple thing I could think of, which would offer the `tap` API that I use and like.

It's really not much, but perhaps you could chime in and tell me what you think.

Some strange things though, I'll try to start a discussion in the code, the test I wrote failed for the example with `rawConnector()` - and I would like to understand why.