### PR TITLE
Events are handled scheduled on the main event loop

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -15,7 +15,13 @@ import { effect } from "./effect";
 /** Holds the registered event handlers. */
 let registry = new Map();
 
-export const eventQueue = queue();
+/**
+ * The event queue scheduling is done at timeouts, without being synchronized
+ * to vertical sync or repaints. Since this is being scheduled in the browser
+ * main event loop, users should avoid stacking too slow blocking operations
+ * in the event handlers.
+ */
+export const eventQueue = queue(fn => setTimeout(fn, 16));
 
 /**
  * Registers an event handler identified by `eventId`.


### PR DESCRIPTION
* This moves the queue for events, and the scheduled flushing-and-
  handling, off from the `requestAnimationFrame`.

  It could be seen as an experiment, in which case it should, in
  theory, allow event-handling - which must not be in itself bound
  to repaints - to be handled without sync to the next frame repaint.

  The current DOM component, will however still schedule any view
  rendering or updates to occur, in sync with, and just before
  the next repaint, on the `requestAnimationFrame`.

An option here would be to merge and simply try-it-out in production - in order to see if it's better or worse. ;-)

